### PR TITLE
Tag howto and processes articles

### DIFF
--- a/docs/articles/licensing/index.rst
+++ b/docs/articles/licensing/index.rst
@@ -21,3 +21,5 @@ tooling in a future proof way. As SPDX is the licensing standard that
 compliance tooling will be using in the future, and indeed already is
 used by tool makers such as WindRiver and Black Duck, they are included
 both for support for tooling and future proofing the format.
+
+.. tags:: process

--- a/docs/articles/sdk/installing-the-sdk.rst
+++ b/docs/articles/sdk/installing-the-sdk.rst
@@ -36,3 +36,5 @@ Example:
     SDK has been successfully set up and is ready to be used.
 
 Now the SDK is installed and can be used.
+
+.. tags:: howto

--- a/docs/articles/workflow/git-workflow.rst
+++ b/docs/articles/workflow/git-workflow.rst
@@ -90,3 +90,4 @@ authors of this document follow and highly recommend `GNOME's commit message gui
 
 .. _`GNOME's commit message guidelines`: https://wiki.gnome.org/Git/CommitMessages/
 
+.. tags:: howto

--- a/docs/categories/howto.rst
+++ b/docs/categories/howto.rst
@@ -1,0 +1,4 @@
+How-to articles
+**************
+
+.. taglist:: howto

--- a/docs/categories/process.rst
+++ b/docs/categories/process.rst
@@ -1,0 +1,4 @@
+Processes
+*********
+
+.. taglist:: process

--- a/docs/index.trst
+++ b/docs/index.trst
@@ -19,3 +19,11 @@ Revision: |release|
     articles/templates/index.rst
 
     articles/workflow/git-workflow.rst
+
+.. toctree::
+    :caption: Categories:
+    :maxdepth: 1
+
+    categories/howto.rst
+
+    categories/process.rst


### PR DESCRIPTION
Create new summary page to list all articles tagged with howto or processes.

I'm not sure which documents are classified as howto and processes but this is a start.
Suggestions?

Signed-off-by: Henrik Hugo <hhugo@luxoft.com>