### PR TITLE
Fix typo in title underline

### DIFF
--- a/docs/categories/howto.rst
+++ b/docs/categories/howto.rst
@@ -1,4 +1,4 @@
 How-to articles
-**************
+***************
 
 .. taglist:: howto


### PR DESCRIPTION
Missed the warning from sphinx output. We have way too many warnings about documents not included in toctrees.

Signed-off-by: Henrik Hugo <hhugo@luxoft.com>