### PR TITLE
Fix 'not included' warnings

### DIFF
--- a/docs/articles/baseplatform/creating-a-new-layer.rst
+++ b/docs/articles/baseplatform/creating-a-new-layer.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Creating a new layer
 ====================
 

--- a/docs/articles/baseplatform/creating-sdk.rst
+++ b/docs/articles/baseplatform/creating-sdk.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Building the SDK installer
 ===========================
 

--- a/docs/articles/baseplatform/prerequisites.rst
+++ b/docs/articles/baseplatform/prerequisites.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Prerequisites for building a |proj_name| image
 ==============================================
 

--- a/docs/articles/baseplatform/repo-manifests.rst
+++ b/docs/articles/baseplatform/repo-manifests.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Manifests
 =========
 

--- a/docs/articles/baseplatform/reproducible-yocto-builds.rst
+++ b/docs/articles/baseplatform/reproducible-yocto-builds.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Reproducible Yocto builds
 =========================
 

--- a/docs/articles/baseplatform/using-the-repo-tool.rst
+++ b/docs/articles/baseplatform/using-the-repo-tool.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _using-the-repo-tool:
 
 Using the repo tool

--- a/docs/articles/baseplatform/variant-concept-in-yocto.rst
+++ b/docs/articles/baseplatform/variant-concept-in-yocto.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Variant concept in Yocto
 ========================
 

--- a/docs/articles/baseplatform/writing-image.rst
+++ b/docs/articles/baseplatform/writing-image.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Writing the image
 =================
 

--- a/docs/articles/infrastructure/ci-cd/build-slaves.rst
+++ b/docs/articles/infrastructure/ci-cd/build-slaves.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Build Slaves
 ============
 

--- a/docs/articles/infrastructure/ci-cd/fossology.rst
+++ b/docs/articles/infrastructure/ci-cd/fossology.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 FOSSology
 =========
 

--- a/docs/articles/infrastructure/ci-cd/host.rst
+++ b/docs/articles/infrastructure/ci-cd/host.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Infrastructure host
 ===================
 

--- a/docs/articles/infrastructure/ci-cd/jenkins.rst
+++ b/docs/articles/infrastructure/ci-cd/jenkins.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Jenkins
 =======
 

--- a/docs/articles/intro/index.rst
+++ b/docs/articles/intro/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Introduction
 ************
 

--- a/docs/articles/licensing/index.rst
+++ b/docs/articles/licensing/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Licensing
 =========
 

--- a/docs/articles/sdk/index.rst
+++ b/docs/articles/sdk/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Software Development Kit
 ************************
 

--- a/docs/articles/sdk/installing-the-sdk.rst
+++ b/docs/articles/sdk/installing-the-sdk.rst
@@ -1,3 +1,4 @@
+:orphan:
 
 .. only:: blueprint
 

--- a/docs/articles/sdk/run-binary-on-target.rst
+++ b/docs/articles/sdk/run-binary-on-target.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Deploying and running a binary executable on target
 ===================================================
 

--- a/docs/articles/sdk/using-the-sdk-to-crosscompile.rst
+++ b/docs/articles/sdk/using-the-sdk-to-crosscompile.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Using the SDK to cross compile
 ==============================
 

--- a/docs/articles/templates/index.rst
+++ b/docs/articles/templates/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 C/C++ templates
 ***************
 

--- a/docs/articles/workflow/git-workflow.rst
+++ b/docs/articles/workflow/git-workflow.rst
@@ -1,3 +1,4 @@
+:orphan:
 
 Git workflow
 ************

--- a/docs/categories/howto.rst
+++ b/docs/categories/howto.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 How-to articles
 ***************
 

--- a/docs/categories/process.rst
+++ b/docs/categories/process.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Processes
 *********
 


### PR DESCRIPTION
Add the orphan metadata field in order to avoid sphinx
warning about 'document isn't included in any toctree'.

Signed-off-by: Henrik Hugo <hhugo@luxoft.com>