### PR TITLE
repo-manifests.rst:Text changes for clarity and consistency.

### DIFF
--- a/docs/articles/baseplatform/repo-manifests.rst
+++ b/docs/articles/baseplatform/repo-manifests.rst
@@ -8,10 +8,10 @@ build. It features a `manifest` format using XML where one defines the git
 repositories and revisions one wants to use. It is possible to include manifests
 in other manifests.
 
-Feature overview
-----------------
-* Download several git repos simultaneously.
-* Use different revisions for different repos.
+Repo feature overview
+---------------------
+* Download several git repositories simultaneously.
+* Use different revisions for different repositories.
 
     * Revisions can be branches, tags or commit hashes.
 
@@ -20,24 +20,25 @@ Feature overview
     * Create more specialized manifests from a common base.
 
 * Default settings for revision etc.
-* Separate remotes and actual repos.
+* Separate remotes and actual repositories.
 
-Usage in yocto
---------------
+Using repo with yocto
+---------------------
 When doing yocto builds, the repo tool is useful to have the various yocto
 layers synced towards the same yocto release (typically, a poky release).
 
-Revisions in repo manifests can be branch names, tags, or commit hashes. For
-maximum reproducibility, commit hashes are a good solution, but in order to be
-able to follow layers as they move, branch names are suitable.
+Revisions in repo manifests can be branch names, tags, or commit
+hashes. Commit hashes are a good solution for reproducing builds, but
+in order to be able to follow layers as they move, branch names are
+preferred.
 
 If one wants to support several yocto releases, it is possible to use different
-branches in the manifest repo, where the manifest in each branch would then
+branches in the manifest repository, where the manifest in each branch would then
 point to the corresponding branch (or a commit on that branch) in the layers
 used.
 
 Example
-^^^^^^^
+-------
 Below is an example of a manifest from PELUX [#pelux-manifests]_ showcasing the
 format.
 
@@ -49,10 +50,10 @@ relative to the current working directory.
 
 Using the repo tool
 -------------------
-In the yocto setting, only two of the repo commands are typically used: ``repo
-init`` and ``repo sync``. The first sets up repo in the current working
-directory, and the second downloads all the git repositories pointed out by the
-manifest selected.
+In the yocto setting, two repo commands are commonly used: ``repo
+init`` and ``repo sync``. The first sets up repo in the current
+working directory, and the second downloads all the git repositories
+in the selected manifest.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Signed-off-by: Jeremiah C. Foster <jeremiah@jeremiahfoster.com>

- The word 'repo' in the text can be confusing, therefor I thought I'd spell it out when we mean 'repository' and leave the word 'repo' to represent the tool repo.
- Some of the text gets a little turgid at times so I tried to simplify it as much as possible.