### PR TITLE
Remove label from jenkins.rst

### DIFF
--- a/docs/articles/infrastructure/ci-cd/jenkins.rst
+++ b/docs/articles/infrastructure/ci-cd/jenkins.rst
@@ -1,7 +1,5 @@
 :orphan:
 
-.. _jenkins:
-
 Jenkins
 =======
 


### PR DESCRIPTION
To be able to include jenkins.rst from other files, labels are needed to be removed from the file.