### PR TITLE
Use the term "deploy" instead of "write" for image

### DIFF
--- a/docs/articles/baseplatform/deploying-image.rst
+++ b/docs/articles/baseplatform/deploying-image.rst
@@ -1,9 +1,9 @@
 :orphan:
 
-Writing the image
-=================
+Deploying the image
+===================
 
-This section describes how to write the build output, a ready disk-image, to a removable media.
+This section describes how to deploy the build output, a ready disk-image, to a removable media.
 Further information can be found in the `Poky documentation`_.
 
 General instructions

--- a/docs/articles/baseplatform/index.trst
+++ b/docs/articles/baseplatform/index.trst
@@ -8,7 +8,7 @@ Base platform
     using-the-repo-tool.rst
     repo-manifests.rst
     reproducible-yocto-builds
-    writing-image.rst
+    deploying-image.rst
     creating-sdk.rst
     creating-a-new-layer.rst
     variant-concept-in-yocto.rst


### PR DESCRIPTION
Instead of talking about "writing an image" it makes more sense to
talk about deploying an image, especially if additional information
about more exotic targets are added where it's more than just writing
to disk.

Signed-off-by: Erik Botö <erik.boto@pelagicore.com>