### PR TITLE
docker-registry: Add reference tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,14 @@ RUN apt-get update && apt-get install -y \
 	git \
 	locales \
 	python3-pip \
-	enchant
+	enchant \
+	plantuml
 
 RUN pip3 install \
 	sphinx_rtd_theme \
 	sphinxcontrib-actdiag \
 	sphinxcontrib-blockdiag \
+	sphinxcontrib-plantuml \
 	sphinxcontrib-manpage \
 	sphinxcontrib-seqdiag \
 	sphinxcontrib-spelling

--- a/docs/articles/infrastructure/ci-cd/docker-registry.rst
+++ b/docs/articles/infrastructure/ci-cd/docker-registry.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _private-docker-registry:
+
 Private Docker Registry
 =======================
 


### PR DESCRIPTION
A tag is needed to reference the chapter from another chapter.

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>