### PR TITLE
Fix badly formatted tables in directory-structure

### DIFF
--- a/docs/articles/templates/directory-structure.rst
+++ b/docs/articles/templates/directory-structure.rst
@@ -40,45 +40,50 @@ directories in the tree structure above. Some directories are only
 relevant in some situations, e.g. a 'test-data' dir is only relevant
 if there is any actual test data of course.
 
-====================================== ===========
+====================================== =======================================================================
 Directory                              Description
-====================================== ===========
-scripts                                Contains e.g. utility scripts that might be needed to e.g. set up an environment or such like.
+====================================== =======================================================================
+scripts                                Contains e.g. utility scripts that might be needed to e.g. set up an
+                                       environment or such like.
 cmake_modules                          Contains any CMake 'find' modules.
-doc                                    Contains Doxygen files for generating reference documentation that is not part of any class
-                                       etc, e.g. introductory pages and topic overviews. Contains design.md, describing the design
-                                       of the component in an arc42 structure.
-doc/images                             Contains images for the design and Doxygen documentation.
-                                       The preferred file format is png. If the image is generated from another document, it is
-                                       recommended to keep that document here as well, e.g. a UML model.
+doc                                    Contains Doxygen files for generating reference documentation that is
+                                       not part of any class etc, e.g. introductory pages and topic overviews.
+                                       Contains design.md, describing the design of the component in an arc42
+                                       structure.
+doc/images                             Contains images for the design and Doxygen documentation. The
+                                       preferred file format is png. If the image is generated from another
+                                       document, it is recommended to keep that document here as well, e.g.
+                                       a UML model.
 component-test                         Contains tests and any stubs used in component tests.
 component-test/test-data               Contains any test data that the component tests uses.
-<component-subdir>/include             Contains any public header files, those that would typically be installed in a development package.
+<component-subdir>/include             Contains any public header files, those that would typically be
+                                       installed in a development package.
 <component-subdir>/src                 Contains source and private header files.
 <component-subdir>/unit-test           Contains unit tests and any stubs used in unit tests.
 <component-subdir>/unit-test/test-data Contains any test data that the unit tests uses.
-====================================== ===========
+====================================== =======================================================================
 
 Mandatory files
 ---------------
 
 Certain files should be found in every repository, those files are described below.
 
-=============== ===========
+=============== =========================================================================================
 File            Description
-=============== ===========
+=============== =========================================================================================
 README(.md)     A top-level README giving a brief introduction to the repository.
                 How to build, how to run tests, other "good to know" information.
                 The .md suffix for markdown syntax may be used.
 LICENSE         The source code and project license.
-DEPENDENCIES    Describes any non-trivial dependency used by a component.
-                Typically a library linked against such as ``libfoo`` would be listed while a compiler and libstdc++ would not be listed.
+DEPENDENCIES    Describes any non-trivial dependency used by a component. Typically a library linked
+                against such as ``libfoo`` would be listed while a compiler and libstdc++ would not be
+                listed.
 CONTRIBUTING.md For OSS projects this file should exist and contain the following information:
                     * How and where to file bug reports and what information is expected in them.
                     * How the development flow works, for instance forks and merge requests.
                     * Brief about code standard
 doc/mainpage.h  Introductory component documentation.
-=============== ===========
+=============== =========================================================================================
 
 Directory naming
 ----------------
@@ -100,4 +105,5 @@ test, e.g. a unit with the name 'mymodule.cpp'/'mymodule.h' would have a
 corresponding unit test implemented in a file named
 'mymodule_unittest.cpp'.
 
-.. note:: The repository meta data files such as the README, license and Makefiles are allowed to use upper case letters in their naming.
+.. note:: The repository meta data files such as the README, license and
+          Makefiles are allowed to use upper case letters in their naming.


### PR DESCRIPTION
The directory-structure.rst file contained two tables that where badly
formatted for newer versions of sphinx. Apparently this is stricter with
newer versions of sphinx.

WARNING: Would love some more testing with older versions of sphinx before this is merged ;). 

Signed-off-by: Oscar Andreasson <oscar.andreasson@pelagicore.com>