### PR TITLE
Configure QtCreator: Add a explanation for replacing CFLAGS/CXXFLAGS

### DIFF
--- a/docs/articles/sdk/configure-qtcreator.rst
+++ b/docs/articles/sdk/configure-qtcreator.rst
@@ -124,7 +124,7 @@ Kit
 * Choose the previously defined PELUX C and C++ compilers from the corresponding combo boxes
 * Change the environment of this kit to the result of the ``env`` command ran in an SDK terminal
     * If ``CC`` and ``CXX`` have default compiler flags, those should be added in ``CFLAGS`` and ``CXXFLAGS``
-      To replace ``CFLAGS`` and ``CXXFLAGS``, use the result of the below command ran in
+      To replace ``CFLAGS`` and ``CXXFLAGS``, use the result of the below commands ran in
       an SDK terminal
 
       ``echo $CC | awk -v c="$CFLAGS" '{first = $1; $1 = ""; print "CFLAGS="$0, c;}'``

--- a/docs/articles/sdk/configure-qtcreator.rst
+++ b/docs/articles/sdk/configure-qtcreator.rst
@@ -123,6 +123,12 @@ Kit
   the result of the ``echo ${SDKTARGETSYSROOT}`` command ran in an SDK terminal
 * Choose the previously defined PELUX C and C++ compilers from the corresponding combo boxes
 * Change the environment of this kit to the result of the ``env`` command ran in an SDK terminal
+    * If ``CC`` and ``CXX`` have default compiler flags, those should be added in ``CFLAGS`` and ``CXXFLAGS``
+      To replace ``CFLAGS`` and ``CXXFLAGS``, use the result of the below command ran in
+      an SDK terminal
+
+      ``echo $CC | awk -v c="$CFLAGS" '{first = $1; $1 = ""; print "CFLAGS="$0, c;}'``
+      ``echo $CXX | awk -v c="$CXXFLAGS" '{first = $1; $1 = ""; print "CXXFLAGS="$0, c;}'``
 * Choose the previously defined debugger from the corresponding combo box
 * Choose the previously defined CMake from the corresponding combo box
 * Change the ``CMake Configuration`` to add a ``CMAKE_SYSROOT:STRING=<sysroot path>``


### PR DESCRIPTION
Configure QtCreator: Add a explanation for replacing CFLAGS/CXXFLAGS

'CC' or 'CXX' environment variable of the sdk-terminal could indicate
not only the compiler executable path but also default compiler flags
which are not specified in 'CFLAGS' or 'CXXFLAGS'.
In this case, those should be added into 'CFLAGS' or 'CXXFLAGS' to
configure Qt creator as same as sdk-terminal.

Signed-off-by: Junil Kim <jjunil79.kim@lge.com>