### PR TITLE
Spellcheck: remove modals

### DIFF
--- a/docs/articles/architecture/arch-vertical-configurations.rst
+++ b/docs/articles/architecture/arch-vertical-configurations.rst
@@ -34,7 +34,7 @@ Requirements
 
 In order to meet safety concerns, an update mechanism has to be fault
 resilient. For instance, if a power failure happens during an update, the
-system shouldn't end up in an inconsistent state. This requirement implies that
+system should not end up in an inconsistent state. This requirement implies that
 updates have to be atomic/transactional. (i.e: never partially applied)
 
 In order to modify the rootfs without affecting the system execution, the

--- a/docs/articles/infrastructure/ci-cd/howto-yocto-cache.rst
+++ b/docs/articles/infrastructure/ci-cd/howto-yocto-cache.rst
@@ -18,7 +18,7 @@ all downloaded packages, including those downloaded over SVN or git or similar,
 and ``sstate-cache`` contains everything that was built, so basically binaries
 plus some meta-data stating that it has actually been built and what version and
 so on. One reason why the meta-data is useful is because otherwise the system
-might try to reuse binaries for x86 when building for armv7, which wouldn't
+might try to reuse binaries for x86 when building for armv7, which would not
 work.
 
 In general, when using a cached build in yocto, there are two options that needs

--- a/docs/articles/sde/introduction_to_sde.rst
+++ b/docs/articles/sde/introduction_to_sde.rst
@@ -18,7 +18,7 @@ Dependencies:
 * VirtualBox
 * Self-extracting SDK package to install into the SDE. See, :ref:`building-the-sdk`.
 
-.. note:: Ubuntu 16.04 default repositories doesn't provide the latest version
+.. note:: Ubuntu 16.04 default repositories do not provide the latest version
    required. Please check the latest version of `Vagrant`_ and `VirtualBox`_ at those links.
 
 .. _`Vagrant`: https://www.vagrantup.com/downloads.html

--- a/docs/articles/sdk/run-binary-on-target.rst
+++ b/docs/articles/sdk/run-binary-on-target.rst
@@ -6,13 +6,13 @@ Deploying and running a binary executable on target
 Once you have a cross compiled binary file, it needs to be installed on the target. To do so the
 easiest way is to use SSH. For that to work you need to know the IP address of your target.
 
-.. note:: If you don't know the IP address of your target, the `Raspberry Pi
+.. note:: If you do not know the IP address of your target, the `Raspberry Pi
           documentation`_ describes how to find a new device on the network.
           This can be used for any target, not just Raspberry Pi
 
 .. _`Raspberry Pi documentation`: https://www.raspberrypi.org/documentation/remote-access/ip-address.md
 
-The default user on the |proj_name| image is `root` and it doesn't ask for a password logging in via SSH.
+The default user on the |proj_name| image is `root` and it does not ask for a password logging in via SSH.
 Use `scp` to copy your binary to the target.
 
 .. code-block:: bash


### PR DESCRIPTION
"Don't", "shouldn't", "didn't" etc. are caught in spellchecker and should be
avoided in the documentation.

Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>