### PR TITLE
Jenkinsfile: archiveArtifacts should use double quotes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ void configureAndBuild(String name, String dir) {
     }
 
     stage("Archive ${name}") {
-        archiveArtifacts artifacts: '${dir}/build/**', fingerprint: true
+        archiveArtifacts artifacts: "${dir}/build/**", fingerprint: true
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Therese Nordqvist <therese.nordqvist@pelagicore.com>