### PR TITLE
Remove auto-update from example service files

### DIFF
--- a/docs/articles/infrastructure/ci-cd/docker-registry.rst
+++ b/docs/articles/infrastructure/ci-cd/docker-registry.rst
@@ -31,8 +31,6 @@ registry.
    TimeoutStartSec=0
    Restart=always
    ExecStartPre=-/usr/bin/docker stop %n
-   ExecStartPre=-/usr/bin/docker rm %n
-   ExecStartPre=/usr/bin/docker pull registry:2
    ExecStart=/usr/bin/docker run --rm --name %n \
              -e REGISTRY_HTTP_ADDR=0.0.0.0:80 \
              -p 8082:80 \

--- a/docs/articles/infrastructure/ci-cd/jenkins.rst
+++ b/docs/articles/infrastructure/ci-cd/jenkins.rst
@@ -19,8 +19,6 @@ The Jenkins project offers preinstalled Docker images which can be used to vastl
    TimeoutStartSec=0
    Restart=always
    ExecStartPre=-/usr/bin/docker stop %n
-   ExecStartPre=-/usr/bin/docker rm %n
-   ExecStartPre=/usr/bin/docker pull jenkinsci/jenkins:lts
    ExecStart=/usr/bin/docker run --rm --name %n -p 8080:8080 --env JENKINS_OPTS="--prefix=/jenkins" --env JENKINS_JAVA_OPTIONS="-Djava.io.tmpdir=$JENKINS_HOME/tmp" -v jenkins_home:/var/jenkins_home -v /var/www/:/var/www/ jenkinsci/jenkins:lts
    
    [Install]


### PR DESCRIPTION
Remove the pre execute command stating docker pull in the example service
files for jenkins and docker-registry. This is due to it causing more
problems that benefit. For instance, sometimes one would like to restart
a service without also updating it.

Signed-off-by: Viktor Sjölind <vsjolind@luxoft.com>